### PR TITLE
correct regex match in updateKeystore.sh

### DIFF
--- a/web-app/server/updateKeystore.sh
+++ b/web-app/server/updateKeystore.sh
@@ -13,12 +13,13 @@ UPDATED_KEYSTORE_ORG_2="$ORG_2_PATH_TO_KEYSTORE$ORG_2_KEYSTORE"
 
 echo $UPDATED_KEYSTORE_ORG_1
 
-# sed -i "s|keystore/|${UPDATED_KEYSTORE}|g" connection.yaml
+# sed -i "s|keystore/.*|${UPDATED_KEYSTORE}|g" connection.yaml
+# .* is regex-ese for "any character followed by zero or more of any character(s)"
 
 echo 'updating connection.yaml Org1 adminPrivateKey path with' ${UPDATED_KEYSTORE_ORG_1}
 
-sed -i -e "s|Admin@org1.example.com/msp/keystore/|$UPDATED_KEYSTORE_ORG_1|g" connection.yaml
+sed -i -e "s|Admin@org1.example.com/msp/keystore/.*|$UPDATED_KEYSTORE_ORG_1|g" connection.yaml
 
 echo 'updating connection.yaml Org2 adminPrivateKey path with' ${UPDATED_KEYSTORE_ORG_2}
 
-sed -i -e "s|Admin@org2.example.com/msp/keystore/|$UPDATED_KEYSTORE_ORG_2|g" connection.yaml
+sed -i -e "s|Admin@org2.example.com/msp/keystore/.*|$UPDATED_KEYSTORE_ORG_2|g" connection.yaml


### PR DESCRIPTION
previous version worked on 1st run but n+1th run would fail due to | not being prefixed with .* any character followed by zero or more of any character(s) 

unwanted append behavior (failure) on n+1th run would reappear in the resulting `connection.yaml` on line 42 and 54 e.g.
```yaml
path: ../../first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/9b39c05b7d2f25164c6a2d567c9b9dbd1dbb58946a896445e0b782620126bbbb_sk9b39c05b7d2f25164c6a2d567c9b9dbd1dbb58946a896445e0b782620126aaaa_sk
```